### PR TITLE
Implement Vulkan Wrapper

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -77,11 +77,30 @@ pub fn getNativePackageVulkan(sdk: *Sdk, package_name: []const u8, vulkan: std.b
 
 /// Returns the smart wrapper for the SDL api. Contains convenient zig types, tagged unions and so on.
 pub fn getWrapperPackage(sdk: *Sdk, package_name: []const u8) std.build.Pkg {
+    const build_options = sdk.builder.addOptions();
+    build_options.addOption(bool, "vulkan", false);
     return sdk.builder.dupePkg(std.build.Pkg{
         .name = sdk.builder.dupe(package_name),
         .path = .{ .path = sdkRoot() ++ "/src/wrapper/sdl.zig" },
         .dependencies = &[_]std.build.Pkg{
+            build_options.getPackage("build_options"),
             sdk.getNativePackage("sdl-native"),
+        },
+    });
+}
+
+/// Returns the smart wrapper for the SDL api with Vulkan support. Contains convenients zig types, tagged
+/// unions and so on.
+pub fn getWrapperPackageVulkan(sdk: *Sdk, package_name: []const u8, vulkan: std.build.Pkg) std.build.Pkg {
+    const build_options = sdk.builder.addOptions();
+    build_options.addOption(bool, "vulkan", true);
+    return sdk.builder.dupePkg(std.build.Pkg{
+        .name = sdk.builder.dupe(package_name),
+        .path = .{ .path = sdkRoot() ++ "/src/wrapper/sdl.zig" },
+        .dependencies = &[_]std.build.Pkg{
+            build_options.getPackage("build_options"),
+            sdk.getNativePackageVulkan("sdl-native", vulkan),
+            vulkan,
         },
     });
 }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -1,10 +1,15 @@
 const std = @import("std");
+const build_options = @import("build_options");
 
 /// Exports the C interface for SDL
 pub const c = @import("sdl-native");
 
 // pub const image = @import("image.zig");
 pub const gl = @import("gl.zig");
+
+usingnamespace if (build_options.vulkan) struct {
+    pub const vulkan = @import("vulkan.zig");
+} else struct {};
 
 pub const Error = error{SdlError};
 
@@ -287,6 +292,9 @@ pub const WindowFlags = struct {
     /// window should be treated as a popup menu (X11 only, >= SDL 2.0.5)
     popup_menu: bool = false, //SDL_WINDOW_POPUP_MENU,
 
+    /// window usable with a Vulkan instance
+    vulkan: bool = false, // SDL_WINDOW_VULKAN,
+
     // fn fromInteger(val: c_uint) WindowFlags {
     //     // TODO: Implement
     //     @panic("niy");
@@ -314,6 +322,7 @@ pub const WindowFlags = struct {
         if (wf.utility) val |= c.SDL_WINDOW_UTILITY;
         if (wf.tooltip) val |= c.SDL_WINDOW_TOOLTIP;
         if (wf.popup_menu) val |= c.SDL_WINDOW_POPUP_MENU;
+        if (wf.vulkan) val |= c.SDL_WINDOW_VULKAN;
         return val;
     }
 };

--- a/src/wrapper/vulkan.zig
+++ b/src/wrapper/vulkan.zig
@@ -1,0 +1,36 @@
+const sdl = @import("sdl.zig");
+const vk = @import("vulkan");
+const std = @import("std");
+
+pub fn loadLibrary(path: []const u8) !void {
+    if (sdl.c.SDL_Vulkan_LoadLibrary(path.ptr) < 0) return sdl.makeError();
+}
+
+pub fn unloadLibrary() void {
+    sdl.c.SDL_Vulkan_UnloadLibrary();
+}
+
+pub fn getProcAddrFn() !vk.PfnGetInstanceProcAddr {
+    return sdl.c.SDL_Vulkan_GetVkGetInstanceProcAddr() orelse return sdl.makeError();
+}
+
+pub fn getInstanceExtensions(allocator: *std.mem.Allocator, window: sdl.Window) ![][*:0]const u8 {
+    var count: c_uint = undefined;
+    if (sdl.c.SDL_Vulkan_GetInstanceExtensions(window.ptr, &count, null) == sdl.c.SDL_FALSE) return sdl.makeError();
+    const extensions = try allocator.alloc([*:0]const u8, count);
+    errdefer allocator.free(extensions);
+    if (sdl.c.SDL_Vulkan_GetInstanceExtensions(window.ptr, &count, extensions.ptr) == sdl.c.SDL_FALSE) return sdl.makeError();
+    return extensions;
+}
+
+pub fn createSurface(window: sdl.Window, instance: vk.Instance) !vk.SurfaceKHR {
+    var surface: vk.SurfaceKHR = undefined;
+    if (sdl.c.SDL_Vulkan_CreateSurface(window.ptr, instance, &surface) == sdl.c.SDL_FALSE) return sdl.makeError();
+    return surface;
+}
+
+pub fn getDrawableSize(window: sdl.Window) sdl.Size {
+    var output: sdl.Size = undefined;
+    sdl.c.SDL_Vulkan_GetDrawableSize(window.ptr, &output.width, &output.height);
+    return output;
+}


### PR DESCRIPTION
This commit adds support for Vulkan to the wrapper API. Use is similar to using the Vulkan bindings, using `getWrapperPackageVulkan` rather than `getWrapperPackage`, passing the Vulkan package obtained from `vulkan-zig`.

I'm not sure whether functions such as `createSurface` are appropriate to put in the `SDL.vulkan` namespace, or whether they should be conditionally compiled as functions in the namespace of (in this case) `sdl.Window`. 

Feedback is much appreciated on this :)