### PR TITLE
Fix build.zig for zig 0.13.0-dev.46+3648d7df1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -500,7 +500,7 @@ const PrepareStubSourceStep = struct {
     }
 
     pub fn getStubFile(self: *Self) LazyPath {
-        return .{ .generated = .{ .file = &self.assembly_source } };
+        return .{ .generated = &self.assembly_source };
     }
 
     fn make(step: *Step, prog_node: *std.Progress.Node) !void {


### PR DESCRIPTION
Fixes build.zig for zig 0.13.0-dev.46+3648d7df1, by changing the `getStubFile` function.