### PR TITLE
Add default colour alpha argument

### DIFF
--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -144,7 +144,7 @@ pub const Color = extern struct {
     r: u8,
     g: u8,
     b: u8,
-    a: u8,
+    a: u8 = 255,
 
     /// returns a initialized color struct with alpha = 255
     pub fn rgb(r: u8, g: u8, b: u8) Color {


### PR DESCRIPTION
When handling Colour, there are times when you do want to consider alpha, but times when you don't and in those cases you want an alpha of 255.

Whilst you can use the rgb function for this, due to the lack of type inference, you have to specify sdl.Color.rgb(x, y, z), whereas with this pr, you can do .{ .r = x, .g = y, .b = z } which is much cleaner, as well as not forcing you to @import sdl.

I would even go as far to argue the removal of the rgb function, however I have not included that in this pr because backwards compatibility as well as this pr taking much longer to get merged, if at all.