### PR TITLE
remove redundant alpha

### DIFF
--- a/examples/native.zig
+++ b/examples/native.zig
@@ -23,15 +23,15 @@ pub fn main() !void {
     const vertices = [_]SDL.SDL_Vertex{
         .{
             .position = .{ .x = 400, .y = 150 },
-            .color = .{ .r = 255, .g = 0, .b = 0 },
+            .color = .{ .r = 255, .g = 0, .b = 0, .a = 255 },
         },
         .{
             .position = .{ .x = 350, .y = 200 },
-            .color = .{ .r = 0, .g = 0, .b = 255 },
+            .color = .{ .r = 0, .g = 0, .b = 255, .a = 255 },
         },
         .{
             .position = .{ .x = 450, .y = 200 },
-            .color = .{ .r = 0, .g = 255, .b = 0 },
+            .color = .{ .r = 0, .g = 255, .b = 0, .a = 255 },
         },
     };
 

--- a/examples/native.zig
+++ b/examples/native.zig
@@ -23,15 +23,15 @@ pub fn main() !void {
     const vertices = [_]SDL.SDL_Vertex{
         .{
             .position = .{ .x = 400, .y = 150 },
-            .color = .{ .r = 255, .g = 0, .b = 0, .a = 255 },
+            .color = .{ .r = 255, .g = 0, .b = 0 },
         },
         .{
             .position = .{ .x = 350, .y = 200 },
-            .color = .{ .r = 0, .g = 0, .b = 255, .a = 255 },
+            .color = .{ .r = 0, .g = 0, .b = 255 },
         },
         .{
             .position = .{ .x = 450, .y = 200 },
-            .color = .{ .r = 0, .g = 255, .b = 0, .a = 255 },
+            .color = .{ .r = 0, .g = 255, .b = 0 },
         },
     };
 

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -148,7 +148,7 @@ pub const Color = extern struct {
 
     /// returns a initialized color struct with alpha = 255
     pub fn rgb(r: u8, g: u8, b: u8) Color {
-        return Color{ .r = r, .g = g, .b = b, .a = 255 };
+        return Color{ .r = r, .g = g, .b = b };
     }
 
     /// returns a initialized color struct


### PR DESCRIPTION
Following #176, a number of .a = 255 specifications are now redundant, and this pr removes those