### PR TITLE
build.zig: use splitScalar instead of split

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -520,7 +520,7 @@ const PrepareStubSourceStep = struct {
         var writer = file.writer();
         try writer.writeAll(".text\n");
 
-        var iter = std.mem.split(u8, sdl2_symbol_definitions, "\n");
+        var iter = std.mem.splitScalar(u8, sdl2_symbol_definitions, '\n');
         while (iter.next()) |line| {
             const sym = std.mem.trim(u8, line, " \r\n\t");
             if (sym.len == 0)


### PR DESCRIPTION
[`std.mem.split` is deprecated](https://ziglang.org/documentation/master/std/#std.mem.split) and doesn't build on Zig master.