### PR TITLE
Clean build files

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ pub fn link(sdk: *Sdk, exe: *LibExeObjStep, linkage: std.Build.LibExeObjStep.Lin
 /// Links SDL2 TTF to the given exe.
 /// **Important:** The target of the `exe` must already be set, otherwise the Sdk will do the wrong thing!
 pub fn linkTtf(sdk: *Sdk, exe: *Compile) void;
+
+/// Links SDL2 Image to the given exe.
+/// **Important:** The target of the `exe` must already be set, otherwise the Sdk will do the wrong thing!
+pub fn linkImage(sdk: *Sdk, exe: *Compile) void;
 ```
 
 ## Dependencies

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -1,2 +1,0 @@
-///! Deprecated, use build.zig directly!
-pub usingnamespace @import("build.zig");

--- a/build.zig
+++ b/build.zig
@@ -117,14 +117,14 @@ prepare_sources: *PrepareStubSourceStep,
 /// Creates a instance of the Sdk and initializes internal steps.
 /// Initialize once, use everywhere (in your `build` function).
 pub fn init(b: *Build, maybe_config_path: ?[]const u8) *Sdk {
-    const sdk = b.allocator.create(Sdk) catch @panic("out of memory");
+    const sdk = b.allocator.create(Sdk) catch @panic("OOM");
     const config_path = maybe_config_path orelse std.fs.path.join(
         b.allocator,
         &[_][]const u8{
             b.pathFromRoot(".build_config"),
             "sdl.json",
         },
-    ) catch @panic("out of memory");
+    ) catch @panic("OOM");
 
     sdk.* = .{
         .build = b,
@@ -275,7 +275,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
         exe.linkSystemLibrary("sdl2");
     } else if (target.result.os.tag == .windows) {
         const sdk_paths = sdk.getPaths(target) catch |err| {
-            const target_name = tripleName(sdk.build.allocator, target) catch @panic("out of memory");
+            const target_name = tripleName(sdk.build.allocator, target) catch @panic("OOM");
 
             switch (err) {
                 error.FileNotFound => {
@@ -340,7 +340,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
             const include_path = std.fs.path.join(b.allocator, &[_][]const u8{
                 sdk_paths.include,
                 "SDL2",
-            }) catch @panic("out of memory");
+            }) catch @panic("OOM");
             exe.addIncludePath(.{ .cwd_relative = include_path });
         } else {
             exe.addIncludePath(.{ .cwd_relative = sdk_paths.include });
@@ -360,7 +360,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
             const lib_path = std.fs.path.join(b.allocator, &[_][]const u8{
                 sdk_paths.libs,
                 file_name,
-            }) catch @panic("out of memory");
+            }) catch @panic("OOM");
 
             exe.addObjectFile(.{ .cwd_relative = lib_path });
 
@@ -389,7 +389,7 @@ pub fn link(sdk: *Sdk, exe: *Compile, linkage: std.builtin.LinkMode) void {
             const sdl2_dll_path = std.fs.path.join(sdk.build.allocator, &[_][]const u8{
                 sdk_paths.bin,
                 "SDL2.dll",
-            }) catch @panic("out of memory");
+            }) catch @panic("OOM");
             sdk.build.installBinFile(sdl2_dll_path, "SDL2.dll");
         }
     } else if (target.result.isDarwin()) {
@@ -474,7 +474,7 @@ const PrepareStubSourceStep = struct {
     assembly_source: GeneratedFile,
 
     pub fn create(sdk: *Sdk) *PrepareStubSourceStep {
-        const psss = sdk.build.allocator.create(Self) catch @panic("out of memory");
+        const psss = sdk.build.allocator.create(Self) catch @panic("OOM");
 
         psss.* = .{
             .step = Step.init(

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = "SDL.zig",
+    .version = "0.0.0",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "src/binding",
+        "LICENSE",
+    },
+}

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -3,7 +3,7 @@ pkgs:
     version: 0.0.0
     description: "A shallow wrapper around SDL that provides object API and error handling"
     license: MIT
-    source_url: "https://github.com/MasterQ32/SDL.zig"
+    source_url: "https://github.com/ikskuh/SDL.zig"
     tags:
       sdl
 


### PR DESCRIPTION
In this PR:
- I did some cleanup in the build file;
- I added the `linkImage` function. I don't know if it is cross-platform;
- I renamed `out of memory` to `OOM` because `OOM` is used in the standard library;
- I added `build.zig.zon`. In the paths I put `LICENSE` (as on `gyro.zzz`), but the file is named `LICENCE`. Maybe we need to make a PR for that.