### PR TITLE
add zig-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .zig-cache
+zig-cache
 zig-out
 deps.zig
 gyro.lock


### PR DESCRIPTION
The zig compiler emits files to a zig-cache folder, and I don't believe these should be committed to git