### PR TITLE
GameController wrapper improvements

### DIFF
--- a/src/binding/sdl.zig
+++ b/src/binding/sdl.zig
@@ -1675,6 +1675,7 @@ pub const SDL_JOYBUTTONDOWN: c_int = 1539;
 pub const SDL_JOYBUTTONUP: c_int = 1540;
 pub const SDL_JOYDEVICEADDED: c_int = 1541;
 pub const SDL_JOYDEVICEREMOVED: c_int = 1542;
+pub const SDL_JOYBATTERYUPDATED: c_int = 1543;
 pub const SDL_CONTROLLERAXISMOTION: c_int = 1616;
 pub const SDL_CONTROLLERBUTTONDOWN: c_int = 1617;
 pub const SDL_CONTROLLERBUTTONUP: c_int = 1618;
@@ -1830,6 +1831,12 @@ pub const SDL_JoyDeviceEvent = extern struct {
     timestamp: u32,
     which: i32,
 };
+pub const SDL_JoyBatteryEvent = extern struct {
+    type: u32,
+    timestamp: u32,
+    which: SDL_JoystickID,
+    level: SDL_JoystickPowerLevel,
+};
 pub const SDL_ControllerAxisEvent = extern struct {
     type: u32,
     timestamp: u32,
@@ -1964,6 +1971,7 @@ pub const SDL_Event = extern union {
     jhat: SDL_JoyHatEvent,
     jbutton: SDL_JoyButtonEvent,
     jdevice: SDL_JoyDeviceEvent,
+    jbattery: SDL_JoyBatteryEvent,
     caxis: SDL_ControllerAxisEvent,
     cbutton: SDL_ControllerButtonEvent,
     cdevice: SDL_ControllerDeviceEvent,

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -2404,8 +2404,8 @@ pub const GameController = struct {
         c.SDL_GameControllerClose(self.ptr);
     }
 
-    pub fn nameForIndex(joystick_index: u31) ?[:0]const u8 {
-        return stringToSlice(c.SDL_GameControllerNameForIndex(joystick_index), 0);
+    pub fn nameForIndex(joystick_index: u31) []const u8 {
+        return stringToSlice(c.SDL_GameControllerNameForIndex(joystick_index));
     }
 
     pub fn getButton(self: GameController, button: Button) u8 {

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -1615,6 +1615,7 @@ pub const Event = union(enum) {
     pub const TextEditingEvent = c.SDL_TextEditingEvent;
     pub const TextInputEvent = c.SDL_TextInputEvent;
     pub const JoyDeviceEvent = c.SDL_JoyDeviceEvent;
+    pub const JoyBatteryEvent = c.SDL_JoyBatteryEvent;
     pub const ControllerDeviceEvent = c.SDL_ControllerDeviceEvent;
     pub const AudioDeviceEvent = c.SDL_AudioDeviceEvent;
     pub const SensorEvent = c.SDL_SensorEvent;
@@ -1652,6 +1653,7 @@ pub const Event = union(enum) {
     joy_button_up: JoyButtonEvent,
     joy_device_added: JoyDeviceEvent,
     joy_device_removed: JoyDeviceEvent,
+    joy_battery_level: JoyBatteryEvent,
     controller_axis_motion: ControllerAxisEvent,
     controller_button_down: ControllerButtonEvent,
     controller_button_up: ControllerButtonEvent,
@@ -1703,6 +1705,7 @@ pub const Event = union(enum) {
             c.SDL_JOYBUTTONUP => Event{ .joy_button_up = JoyButtonEvent.fromNative(raw.jbutton) },
             c.SDL_JOYDEVICEADDED => Event{ .joy_device_added = raw.jdevice },
             c.SDL_JOYDEVICEREMOVED => Event{ .joy_device_removed = raw.jdevice },
+            c.SDL_JOYBATTERYUPDATED => Event{ .joy_battery_level = raw.jbattery },
             c.SDL_CONTROLLERAXISMOTION => Event{ .controller_axis_motion = ControllerAxisEvent.fromNative(raw.caxis) },
             c.SDL_CONTROLLERBUTTONDOWN => Event{ .controller_button_down = ControllerButtonEvent.fromNative(raw.cbutton) },
             c.SDL_CONTROLLERBUTTONUP => Event{ .controller_button_up = ControllerButtonEvent.fromNative(raw.cbutton) },

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -2393,6 +2393,10 @@ pub const GameController = struct {
         };
     }
 
+    pub fn is(joystick_index: u31) bool {
+        return c.SDL_IsGameController(joystick_index) > 0;
+    }
+
     pub fn close(self: GameController) void {
         c.SDL_GameControllerClose(self.ptr);
     }

--- a/src/wrapper/sdl.zig
+++ b/src/wrapper/sdl.zig
@@ -2420,6 +2420,10 @@ pub const GameController = struct {
         return @as(f32, @floatFromInt(self.getAxis(axis))) / @as(f32, @floatFromInt(c.SDL_JOYSTICK_AXIS_MAX));
     }
 
+    pub fn instanceId(self: GameController) c.SDL_JoystickID {
+        return c.SDL_JoystickInstanceID(c.SDL_GameControllerGetJoystick(self.ptr));
+    }
+
     pub const Button = enum(i32) {
         a = c.SDL_CONTROLLER_BUTTON_A,
         b = c.SDL_CONTROLLER_BUTTON_B,


### PR DESCRIPTION
* Expose joy battery level event, it is send by more recent SDL2 versions when you have a game controller plugged-in. 
* Expose SDL_IsGameController() as `SDL.GameController.is()
* Add `GameController.instanceId()` to get the joystick instance ID, required to handle controller removed event properly.
* Fix `GameController.nameForIndex()` to return the correct type