### PR TITLE
fix: rename Sdk.build -> Sdk.sdl_build to prevent build.zig's build f…

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -123,7 +123,7 @@ const SdkOption = struct {
     maybe_sdl_ttf_config_path: ?[]const u8 = null,
 };
 
-build: *Build,
+sdl_build: *Build,
 sdl_config_path: []const u8,
 
 prepare_sources: *PrepareStubSourceStep,
@@ -150,7 +150,7 @@ pub fn init(b: *Build, opt: SdkOption) *Sdk {
         b;
 
     sdk.* = .{
-        .build = builder,
+        .sdl_build = builder,
         .sdl_config_path = sdl_config_path,
         .sdl_ttf_config_path = sdl_ttf_config_path,
         .prepare_sources = undefined,
@@ -164,13 +164,13 @@ pub fn init(b: *Build, opt: SdkOption) *Sdk {
 /// for a more *ziggy* feeling.
 /// This is similar to the *C import* result.
 pub fn getNativeModule(sdk: *Sdk) *Build.Module {
-    const build_options = sdk.build.addOptions();
+    const build_options = sdk.sdl_build.addOptions();
     build_options.addOption(bool, "vulkan", false);
-    return sdk.build.createModule(.{
-        .root_source_file = sdk.build.path("src/binding/sdl.zig"),
+    return sdk.sdl_build.createModule(.{
+        .root_source_file = sdk.sdl_build.path("src/binding/sdl.zig"),
         .imports = &.{
             .{
-                .name = sdk.build.dupe("build_options"),
+                .name = sdk.sdl_build.dupe("build_options"),
                 .module = build_options.createModule(),
             },
         },
@@ -182,17 +182,17 @@ pub fn getNativeModule(sdk: *Sdk) *Build.Module {
 /// provided as an argument.
 /// This is similar to the *C import* result.
 pub fn getNativeModuleVulkan(sdk: *Sdk, vulkan: *Build.Module) *Build.Module {
-    const build_options = sdk.build.addOptions();
+    const build_options = sdk.sdl_build.addOptions();
     build_options.addOption(bool, "vulkan", true);
-    return sdk.build.createModule(.{
-        .root_source_file = sdk.build.path("src/binding/sdl.zig"),
+    return sdk.sdl_build.createModule(.{
+        .root_source_file = sdk.sdl_build.path("src/binding/sdl.zig"),
         .imports = &.{
             .{
-                .name = sdk.build.dupe("build_options"),
+                .name = sdk.sdl_build.dupe("build_options"),
                 .module = build_options.createModule(),
             },
             .{
-                .name = sdk.build.dupe("vulkan"),
+                .name = sdk.sdl_build.dupe("vulkan"),
                 .module = vulkan,
             },
         },
@@ -201,11 +201,11 @@ pub fn getNativeModuleVulkan(sdk: *Sdk, vulkan: *Build.Module) *Build.Module {
 
 /// Returns the smart wrapper for the SDL api. Contains convenient zig types, tagged unions and so on.
 pub fn getWrapperModule(sdk: *Sdk) *Build.Module {
-    return sdk.build.createModule(.{
-        .root_source_file = sdk.build.path("src/wrapper/sdl.zig"),
+    return sdk.sdl_build.createModule(.{
+        .root_source_file = sdk.sdl_build.path("src/wrapper/sdl.zig"),
         .imports = &.{
             .{
-                .name = sdk.build.dupe("sdl-native"),
+                .name = sdk.sdl_build.dupe("sdl-native"),
                 .module = sdk.getNativeModule(),
             },
         },
@@ -215,15 +215,15 @@ pub fn getWrapperModule(sdk: *Sdk) *Build.Module {
 /// Returns the smart wrapper with Vulkan support. The Vulkan module provided by `vulkan-zig` must be
 /// provided as an argument.
 pub fn getWrapperModuleVulkan(sdk: *Sdk, vulkan: *Build.Module) *Build.Module {
-    return sdk.build.createModule(.{
-        .root_source_file = sdk.build.path("src/wrapper/sdl.zig"),
+    return sdk.sdl_build.createModule(.{
+        .root_source_file = sdk.sdl_build.path("src/wrapper/sdl.zig"),
         .imports = &.{
             .{
-                .name = sdk.build.dupe("sdl-native"),
+                .name = sdk.sdl_build.dupe("sdl-native"),
                 .module = sdk.getNativeModuleVulkan(vulkan),
             },
             .{
-                .name = sdk.build.dupe("vulkan"),
+                .name = sdk.sdl_build.dupe("vulkan"),
                 .module = vulkan,
             },
         },
@@ -231,7 +231,7 @@ pub fn getWrapperModuleVulkan(sdk: *Sdk, vulkan: *Build.Module) *Build.Module {
 }
 
 fn linkLinuxCross(sdk: *Sdk, exe: *Compile) !void {
-    const build_linux_sdl_stub = sdk.build.addSharedLibrary(.{
+    const build_linux_sdl_stub = sdk.sdl_build.addSharedLibrary(.{
         .name = "SDL2",
         .target = exe.root_module.resolved_target.?,
         .optimize = exe.root_module.optimize.?,
@@ -258,14 +258,14 @@ fn linkWindows(
     if (exe.root_module.resolved_target.?.result.abi == .msvc) {
         exe.linkSystemLibrary2(lib_name, .{ .use_pkg_config = .no });
     } else {
-        const file_name = try std.fmt.allocPrint(sdk.build.allocator, "lib{s}.{s}", .{
+        const file_name = try std.fmt.allocPrint(sdk.sdl_build.allocator, "lib{s}.{s}", .{
             lib_name,
             if (linkage == .static) "a" else "dll.a",
         });
-        defer sdk.build.allocator.free(file_name);
+        defer sdk.sdl_build.allocator.free(file_name);
 
-        const lib_path = try std.fs.path.join(sdk.build.allocator, &[_][]const u8{ paths.libs, file_name });
-        defer sdk.build.allocator.free(lib_path);
+        const lib_path = try std.fs.path.join(sdk.sdl_build.allocator, &[_][]const u8{ paths.libs, file_name });
+        defer sdk.sdl_build.allocator.free(lib_path);
 
         exe.addObjectFile(.{ .cwd_relative = lib_path });
 
@@ -287,13 +287,13 @@ fn linkWindows(
     }
 
     if (linkage == .dynamic and exe.kind == .exe) {
-        const dll_name = try std.fmt.allocPrint(sdk.build.allocator, "{s}.dll", .{lib_name});
-        defer sdk.build.allocator.free(dll_name);
+        const dll_name = try std.fmt.allocPrint(sdk.sdl_build.allocator, "{s}.dll", .{lib_name});
+        defer sdk.sdl_build.allocator.free(dll_name);
 
-        const dll_path = try std.fs.path.join(sdk.build.allocator, &[_][]const u8{ paths.bin, dll_name });
-        defer sdk.build.allocator.free(dll_path);
+        const dll_path = try std.fs.path.join(sdk.sdl_build.allocator, &[_][]const u8{ paths.bin, dll_name });
+        defer sdk.sdl_build.allocator.free(dll_path);
 
-        const install_bin = sdk.build.addInstallBinFile(.{ .cwd_relative = dll_path }, dll_name);
+        const install_bin = sdk.sdl_build.addInstallBinFile(.{ .cwd_relative = dll_path }, dll_name);
         exe.step.dependOn(&install_bin.step);
     }
 }
@@ -335,7 +335,7 @@ pub fn link(
     linkage: std.builtin.LinkMode,
     comptime library: Library,
 ) void {
-    const b = sdk.build;
+    const b = sdk.sdl_build;
     const target = exe.root_module.resolved_target.?;
     const is_native = target.query.isNativeOs();
 
@@ -402,8 +402,8 @@ const GetPathsError = error{
 
 fn printPathsErrorMessage(sdk: *Sdk, config_path: []const u8, target_local: std.Build.ResolvedTarget, err: GetPathsError, library: Library) !void {
     const writer = std.io.getStdErr().writer();
-    const target_name = try tripleName(sdk.build.allocator, target_local);
-    defer sdk.build.allocator.free(target_name);
+    const target_name = try tripleName(sdk.sdl_build.allocator, target_local);
+    defer sdk.sdl_build.allocator.free(target_name);
 
     const lib_name = switch (library) {
         .SDL2 => "SDL2",
@@ -458,7 +458,7 @@ fn printPathsErrorMessage(sdk: *Sdk, config_path: []const u8, target_local: std.
 }
 
 fn getPaths(sdk: *Sdk, config_path: []const u8, target_local: std.Build.ResolvedTarget, library: Library) GetPathsError!Paths {
-    const json_data = std.fs.cwd().readFileAlloc(sdk.build.allocator, config_path, 1 << 20) catch |err| switch (err) {
+    const json_data = std.fs.cwd().readFileAlloc(sdk.sdl_build.allocator, config_path, 1 << 20) catch |err| switch (err) {
         error.FileNotFound => {
             printPathsErrorMessage(sdk, config_path, target_local, GetPathsError.FileNotFound, library) catch |e| {
                 std.debug.panic("Failed to print error message: {s}", .{@errorName(e)});
@@ -470,9 +470,9 @@ fn getPaths(sdk: *Sdk, config_path: []const u8, target_local: std.Build.Resolved
             return GetPathsError.FileNotFound;
         },
     };
-    defer sdk.build.allocator.free(json_data);
+    defer sdk.sdl_build.allocator.free(json_data);
 
-    const parsed = std.json.parseFromSlice(std.json.Value, sdk.build.allocator, json_data, .{}) catch {
+    const parsed = std.json.parseFromSlice(std.json.Value, sdk.sdl_build.allocator, json_data, .{}) catch {
         printPathsErrorMessage(sdk, config_path, target_local, GetPathsError.InvalidJson, library) catch |e| {
             std.debug.panic("Failed to print error message: {s}", .{@errorName(e)});
         };
@@ -483,7 +483,7 @@ fn getPaths(sdk: *Sdk, config_path: []const u8, target_local: std.Build.Resolved
     var root_node = parsed.value.object;
     var config_iterator = root_node.iterator();
     while (config_iterator.next()) |entry| {
-        const config_target = sdk.build.resolveTargetQuery(
+        const config_target = sdk.sdl_build.resolveTargetQuery(
             std.Target.Query.parse(.{ .arch_os_abi = entry.key_ptr.* }) catch {
                 std.log.err("Invalid target in config file: {s}", .{entry.key_ptr.*});
                 return GetPathsError.InvalidTarget;
@@ -500,9 +500,9 @@ fn getPaths(sdk: *Sdk, config_path: []const u8, target_local: std.Build.Resolved
         const node = entry.value_ptr.*.object;
 
         return Paths{
-            .include = sdk.build.allocator.dupe(u8, node.get("include").?.string) catch @panic("out of memory"),
-            .libs = sdk.build.allocator.dupe(u8, node.get("libs").?.string) catch @panic("out of memory"),
-            .bin = sdk.build.allocator.dupe(u8, node.get("bin").?.string) catch @panic("out of memory"),
+            .include = sdk.sdl_build.allocator.dupe(u8, node.get("include").?.string) catch @panic("out of memory"),
+            .libs = sdk.sdl_build.allocator.dupe(u8, node.get("libs").?.string) catch @panic("out of memory"),
+            .bin = sdk.sdl_build.allocator.dupe(u8, node.get("bin").?.string) catch @panic("out of memory"),
         };
     }
 
@@ -521,14 +521,14 @@ const PrepareStubSourceStep = struct {
     assembly_source: GeneratedFile,
 
     pub fn create(sdk: *Sdk) *PrepareStubSourceStep {
-        const psss = sdk.build.allocator.create(Self) catch @panic("out of memory");
+        const psss = sdk.sdl_build.allocator.create(Self) catch @panic("out of memory");
 
         psss.* = .{
             .step = Step.init(
                 .{
                     .id = .custom,
                     .name = "Prepare SDL2 stub sources",
-                    .owner = sdk.build,
+                    .owner = sdk.sdl_build,
                     .makeFn = make,
                 },
             ),
@@ -547,7 +547,7 @@ const PrepareStubSourceStep = struct {
         _ = make_opt;
         const self: *Self = @fieldParentPtr("step", step);
 
-        var cache = CacheBuilder.init(self.sdk.build, "sdl");
+        var cache = CacheBuilder.init(self.sdk.sdl_build, "sdl");
 
         cache.addBytes(sdl2_symbol_definitions);
 
@@ -571,7 +571,7 @@ const PrepareStubSourceStep = struct {
             try writer.writeAll("  .byte 0\n");
         }
 
-        self.assembly_source.path = try std.fs.path.join(self.sdk.build.allocator, &[_][]const u8{
+        self.assembly_source.path = try std.fs.path.join(self.sdk.sdl_build.allocator, &[_][]const u8{
             dirpath.path,
             "sdl.S",
         });


### PR DESCRIPTION
The build.zig's Sdk.build field has a naming clash with build.zig's Sdk.build() function. I renamed the Sdk.build field to Sdk.sdl_build to prevent this naming clash.

As per Action: Continuous Build #1722
```
Run zig build install
/home/runner/work/SDL.zig/SDL.zig/build.zig:12:8: error: duplicate struct member name 'build'
/home/runner/work/SDL.zig/SDL.zig/build.zig:126:1: note: duplicate name here
/home/runner/work/SDL.zig/SDL.zig/build.zig:1:1: note: struct declared here
Error: Process completed with exit code 2.
```