### PR TITLE
improve zig 0.13 compatability

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -543,7 +543,7 @@ const PrepareStubSourceStep = struct {
         return .{ .generated = .{ .file = &self.assembly_source } };
     }
 
-    fn make(step: *Step, make_opt: std.Build.Step.MakeOptions) !void {
+    fn make(step: *Step, make_opt: std.Progress.Node) !void {
         _ = make_opt;
         const self: *Self = @fieldParentPtr("step", step);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,9 @@
+.{
+    .name = "SDL",
+    .version = "0.0.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    }
+}


### PR DESCRIPTION
this fixes a build error under zig 0.13 and adds a build.zig.zon in order for better interfacing with the zig package manager.