### PR TITLE
include stubs in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,5 +8,6 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "stubs",
     }
 }


### PR DESCRIPTION
Stubs were missing in the build.zig.zon, without it on the list they were not pulled when you `zig fetch`. Which causes a build failure.

Stubs are needed in the [build.zig](https://github.com/ikskuh/SDL.zig/blob/4e83984a7614ecf781ae0d98717db18fbe53014d/build.zig#L118) with an `@embed`. 